### PR TITLE
Fix bcrypt compatibility error in auth

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -11,11 +11,13 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    truncated = password.encode("utf-8")[:72].decode("utf-8", errors="ignore")
+    return pwd_context.hash(truncated)
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    return pwd_context.verify(plain, hashed)
+    truncated = plain.encode("utf-8")[:72].decode("utf-8", errors="ignore")
+    return pwd_context.verify(truncated, hashed)
 
 
 def create_access_token(data: dict) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ sqlalchemy
 alembic
 psycopg2-binary
 python-jose[cryptography]
-passlib[bcrypt]
+passlib==1.7.4
+bcrypt==4.0.1
 python-multipart


### PR DESCRIPTION
Fix bcrypt compatibility errors in auth.

- Pin passlib==1.7.4 and bcrypt==4.0.1 in requirements.txt to resolve AttributeError on bcrypt.__about__
- Truncate passwords to 72 bytes in hash_password and verify_password to prevent ValueError

Fixes #17

Generated with [Claude Code](https://claude.ai/code)