### PR TITLE
Fix JWT token sub field causing 401 on /auth/me

### DIFF
--- a/routers/auth_router.py
+++ b/routers/auth_router.py
@@ -43,13 +43,13 @@ def get_current_user(
 ) -> User:
     try:
         payload = decode_token(credentials.credentials)
-        user_id: int = payload.get("sub")
+        user_id = payload.get("sub")
         if user_id is None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     except JWTError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
-    user = db.query(User).filter(User.id == user_id).first()
+    user = db.query(User).filter(User.id == int(user_id)).first()
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
     return user
@@ -68,7 +68,7 @@ def signup(request: SignupRequest, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     db.refresh(user)
-    token = create_access_token({"sub": user.id})
+    token = create_access_token({"sub": str(user.id)})
     return TokenResponse(access_token=token)
 
 
@@ -77,7 +77,7 @@ def login(request: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == request.email).first()
     if not user or not verify_password(request.password, user.password_hash):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
-    token = create_access_token({"sub": user.id})
+    token = create_access_token({"sub": str(user.id)})
     return TokenResponse(access_token=token)
 
 


### PR DESCRIPTION
Fixes #25

Store user.id as string in JWT sub field and parse it back to int when reading, fixing inconsistent serialization by python-jose that caused 401 errors on /auth/me after successful login.

Generated with [Claude Code](https://claude.ai/code)